### PR TITLE
[Pull Request] Update PyQt5 Dependency and Bug Fixes

### DIFF
--- a/mv_draft/canvas.py
+++ b/mv_draft/canvas.py
@@ -331,8 +331,8 @@ class Canvas(QWidget):
             scale_w = self.background_pixmap.width() / self.label.width()
             scale_h = self.background_pixmap.height() / self.label.height()
             Canvas.last_point = QPoint(
-                event.pos().x() * scale_w - self.cursor_size // 2,
-                event.pos().y() * scale_h - self.cursor_size // 2,
+                round(event.pos().x() * scale_w - self.cursor_size // 2),
+                round(event.pos().y() * scale_h - self.cursor_size // 2),
             )
 
     def mouseReleaseEvent(self, event):
@@ -389,13 +389,13 @@ class Canvas(QWidget):
             painter = QPainter(self.mine_layer)
 
             # 将icon绘制到中心位置，假设icon的大小为 icon_size x icon_size
-            icon_size = min(cell_width, cell_height) * 1.3  # 调整图标的大小以适应单元格
+            icon_size = round(min(cell_width, cell_height) * 1.3)  # 调整图标的大小以适应单元格
             icon = icon.scaled(
                 icon_size, icon_size, Qt.KeepAspectRatio, Qt.SmoothTransformation
             )  # 调整图标大小
 
             # 将icon绘制到中心位置
-            painter.drawPixmap(icon_x - icon_size / 2, icon_y - icon_size / 2, icon)
+            painter.drawPixmap(round(icon_x - icon_size / 2), round(icon_y - icon_size / 2), icon)
             painter.end()
             self.refresh_display()
 
@@ -426,8 +426,8 @@ class Canvas(QWidget):
         """
         scale_width = self.background_pixmap.width() / self.label.width()
         scale_height = self.background_pixmap.height() / self.label.height()
-        scaled_x = event.pos().x() * scale_width - self.cursor_size // 2
-        scaled_y = event.pos().y() * scale_height - self.cursor_size // 2
+        scaled_x = round(event.pos().x() * scale_width - self.cursor_size // 2)
+        scaled_y = round(event.pos().y() * scale_height - self.cursor_size // 2)
         return QPoint(scaled_x, scaled_y)
 
     def choose_color(self):

--- a/mv_draft/canvas.py
+++ b/mv_draft/canvas.py
@@ -317,9 +317,9 @@ class Canvas(QWidget):
             # Draw grid
             for i in range(n + 1):
                 # Draw horizontal lines
-                painter.drawLine(x1, y1 + i * cell_height, x2, y1 + i * cell_height)
+                painter.drawLine(x1, round(y1 + i * cell_height), x2, round(y1 + i * cell_height))
                 # Draw vertical lines
-                painter.drawLine(x1 + i * cell_width, y1, x1 + i * cell_width, y2)
+                painter.drawLine(round(x1 + i * cell_width), y1, round(x1 + i * cell_width), y2)
 
             # End drawing
             painter.end()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 opencv_python
 Pillow
-PyQt5==5.12
+PyQt5
 setuptools


### PR DESCRIPTION
## Summary

PyQt5 <= 5.13 version is not compatible with Python >= 3.11. Therefore `pip install -e .` command fails. 

This PR removes the PyQt5 version constraint from the `requirements.txt` file to fix the issue.

Additionally, several methods no longer accepts float values as arguments in the latest PyQt5 version:

- `qpainter.drawLine(x1 : int, y1 : int, x2 : int, y2 : int)`
- `qpainter.drawPixmap(x : int, y : int, pixmap : QPixmap)`
- `QPoint(x : int, y : int)` (constructor)
- `QPixMap.scaled(w : int, h : int, aspectRatioMode : Qt.AspectRatioMode = Qt.IgnoreAspectRatio, transformMode : Qt.TransformationMode = Qt.FastTransformation)`

This PR fixes the above issues by rounding the float values to integers. This may not be the best solution, but it works for now.
